### PR TITLE
Add citation download routes

### DIFF
--- a/site/config/config.php
+++ b/site/config/config.php
@@ -103,6 +103,24 @@ return [
         return go("https://index-press.com/", 301);
       }
     ],
+    [
+      'pattern' => 'citation/bibtex/(:all)',
+      'action'  => function ($id) {
+        if (!$page = page($id)) {
+          return new Kirby\Cms\Response('Page not found', 'text/plain', 404);
+        }
+        return new Kirby\Cms\Response(citationBibtex($page), 'text/x-bibtex');
+      }
+    ],
+    [
+      'pattern' => 'citation/ris/(:all)',
+      'action'  => function ($id) {
+        if (!$page = page($id)) {
+          return new Kirby\Cms\Response('Page not found', 'text/plain', 404);
+        }
+        return new Kirby\Cms\Response(citationRis($page), 'application/x-research-info-systems');
+      }
+    ],
 
   ],
   # https://getkirby.com/docs/reference/system/options/email

--- a/site/plugins/citation/index.php
+++ b/site/plugins/citation/index.php
@@ -1,0 +1,52 @@
+<?php
+
+function citationBibtex(Kirby\Cms\Page $page): string {
+    $authors = [];
+    foreach ($page->authors()->yaml() as $author) {
+        $authors[] = $author['last_name'] . ', ' . $author['first_name'];
+    }
+    $authorsStr = implode(' and ', $authors);
+    $title = $page->title()->value();
+    if ($page->subtitle()->isNotEmpty()) {
+        $title .= ': ' . $page->subtitle()->value();
+    }
+    $year = $page->parent()->issue_date()->toDate('Y');
+    $doi = $page->doi()->value();
+    $id = $page->slug();
+    $bibtex = "@article{{$id},\n";
+    $bibtex .= "  title={{" . $title . "}},\n";
+    if (!empty($authorsStr)) {
+        $bibtex .= "  author={{" . $authorsStr . "}},\n";
+    }
+    $bibtex .= "  journal={{" . $page->site()->title()->value() . "}},\n";
+    $bibtex .= "  year={{" . $year . "}},\n";
+    if (!empty($doi)) {
+        $bibtex .= "  doi={{" . $doi . "}},\n";
+    }
+    $bibtex .= "  url={{" . $page->url() . "}}\n";
+    $bibtex .= "}\n";
+    return $bibtex;
+}
+
+function citationRis(Kirby\Cms\Page $page): string {
+    $ris = [];
+    $ris[] = 'TY  - JOUR';
+    foreach ($page->authors()->yaml() as $author) {
+        $ris[] = 'AU  - ' . $author['last_name'] . ', ' . $author['first_name'];
+    }
+    $title = $page->title()->value();
+    if ($page->subtitle()->isNotEmpty()) {
+        $title .= ': ' . $page->subtitle()->value();
+    }
+    $ris[] = 'TI  - ' . $title;
+    $ris[] = 'T2  - ' . $page->site()->title()->value();
+    $ris[] = 'PY  - ' . $page->parent()->issue_date()->toDate('Y');
+    if ($page->doi()->isNotEmpty()) {
+        $ris[] = 'DO  - ' . $page->doi()->value();
+    }
+    $ris[] = 'UR  - ' . $page->url();
+    $ris[] = 'ER  -';
+    return implode("\n", $ris) . "\n";
+}
+
+Kirby::plugin('custom/citation', []);

--- a/site/templates/emaj-essay.php
+++ b/site/templates/emaj-essay.php
@@ -27,7 +27,20 @@
       <?= smartypants($page->bibilography()->kirbytext()) ?>
     </div>
 
-    <?php if ($page->slug() != 'introduction') : ?><span class="essay-extra">(<?php if ($page->doi()->isNotEmpty()) : ?><span class="doi">DOI: <a href="https://doi.org/<?= $page->doi() ?>"><?= $page->doi() ?></span></a><?php endif ?><?php if ($page->hasDocuments()) : ?><span class="pdf"><a href="<?= $page->documents()->first()->url() ?>" target="_blank">PDF</a></span><?php endif ?>)</span><?php endif ?>
+    <?php if ($page->slug() != 'introduction') : ?>
+      <span class="essay-extra">
+        <?php if ($page->doi()->isNotEmpty()) : ?>
+          <span class="doi">DOI: <a href="https://doi.org/<?= $page->doi() ?>"><?= $page->doi() ?></a></span>
+        <?php endif ?>
+        <?php if ($page->hasDocuments()) : ?>
+          <span class="pdf"><a href="<?= $page->documents()->first()->url() ?>" target="_blank">PDF</a></span>
+        <?php endif ?>
+        <span class="citation">
+          <a href="<?= url('citation/bibtex/' . $page->id()) ?>">BibTeX</a> |
+          <a href="<?= url('citation/ris/' . $page->id()) ?>">RIS</a>
+        </span>
+      </span>
+    <?php endif ?>
   </div>
 
 </main>

--- a/site/templates/essay.php
+++ b/site/templates/essay.php
@@ -71,6 +71,10 @@
             <a href="http://doi.org/<?= $page->doi() ?>"><?= $page->doi() ?></a>
           </span>
         <?php endif ?>
+        <span class="citation">
+          <a href="<?= url('citation/bibtex/' . $page->id()) ?>">BibTeX</a> |
+          <a href="<?= url('citation/ris/' . $page->id()) ?>">RIS</a>
+        </span>
       </span>
     <?php endif ?>
 </main>

--- a/site/templates/special-issue-essay.php
+++ b/site/templates/special-issue-essay.php
@@ -71,6 +71,10 @@
             <a href="http://doi.org/<?= $page->doi() ?>"><?= $page->doi() ?></a>
           </span>
         <?php endif ?>
+        <span class="citation">
+          <a href="<?= url('citation/bibtex/' . $page->id()) ?>">BibTeX</a> |
+          <a href="<?= url('citation/ris/' . $page->id()) ?>">RIS</a>
+        </span>
       </span>
     <?php endif ?>
 </main>


### PR DESCRIPTION
## Summary
- generate BibTeX and RIS citations
- expose routes `citation/bibtex/<id>` and `citation/ris/<id>`
- link to citation downloads in essay templates

## Testing
- `npm run build` *(fails: connect EHOSTUNREACH)*