### PR TITLE
Implement Crossref XML submission

### DIFF
--- a/site/blueprints/pages/issue.yml
+++ b/site/blueprints/pages/issue.yml
@@ -3,16 +3,22 @@ title: Issue
 tabs:
   content:
     sections:
-      # registration:
-      #   type: fields
-      #   fields:
-      #     crossrefButton:
-      #       type: button
-      #       label: CrossRef XML
-      #       text: Downlaod CrossRef XML File
-      #       url: /generate-xml/{{ page.id }}
-      #       theme: positive
-      #       # reload: true # trigger a page refresh on success to display updated data
+      registration:
+        type: fields
+        fields:
+          crossrefXML:
+            type: button
+            label: CrossRef XML
+            text: Download CrossRef XML File
+            url: /generate-xml/{{ page.id }}
+            theme: positive
+          crossrefSubmit:
+            type: button
+            label: Submit to Crossref
+            text: Send XML to Crossref
+            url: /submit-crossref/{{ page.id }}
+            theme: positive
+            open: true
       builder:
         headline: Builder
         type: fields

--- a/site/config/config.php
+++ b/site/config/config.php
@@ -105,6 +105,13 @@ return [
     ],
 
   ],
+
+  'crossref' => [
+    'username' => env('CROSSREF_USERNAME'),
+    'password' => env('CROSSREF_PASSWORD'),
+    'token'    => env('CROSSREF_TOKEN'),
+    'apiUrl'   => env('CROSSREF_API_URL', 'https://api.crossref.org/deposits')
+  ],
   # https://getkirby.com/docs/reference/system/options/email
   'email' => [
     'transport' => [


### PR DESCRIPTION
## Summary
- extend crossref plugin with route to send generated XML to Crossref
- provide button for Crossref XML generation and submission
- configure Crossref authentication via `.env` values

## Testing
- `php -l site/plugins/crossref-register/index.php` *(fails: `php` not found)*