### PR TITLE
Fix apt installation issue in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,12 +29,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     php-zip && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install imagemagick
+# Install imagemagick and utilities
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends apt-utils
-
-RUN apt-get update && \
-    apt-get install -y imagemagick
+    apt-get install -y --no-install-recommends apt-utils imagemagick --fix-missing && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 # Copy virtual host configuration from current path onto existing 000-default.conf
 COPY default.conf /etc/apache2/sites-available/000-default.conf
 


### PR DESCRIPTION
## Summary
- update Dockerfile to combine imagemagick and apt-utils install step with `--fix-missing`
- clean apt lists after installation

## Testing
- `composer test` *(fails: command not found)*
- `npm test` *(fails: missing script)*