### PR TITLE
Fix deprecated implicit nullable parameters

### DIFF
--- a/site/plugins/crossref-register/index.php
+++ b/site/plugins/crossref-register/index.php
@@ -14,7 +14,7 @@ function crossrefOptions(): array
     ];
 }
 
-function validateCrossrefSettings(array $opts, array $keys = null): ?Response
+function validateCrossrefSettings(array $opts, ?array $keys = null): ?Response
 {
     $labels = [
         'username'     => 'Crossref username',
@@ -196,7 +196,7 @@ function generateBatchId(): string
  * POST the XML to Crossref and return a detailed result object.
  * Uses the correct multipart/form-data payload.
  */
-function sendToCrossref(string $xml, array $opt = null): string
+function sendToCrossref(string $xml, ?array $opt = null): string
 {
     $opt ??= crossrefOptions();
 


### PR DESCRIPTION
## Summary
- address PHP 8.2 deprecation about implicitly nullable parameters in crossref plugin

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683befd775048332ac9d3960b7f90425