### PR TITLE
Add DOCX export feature

### DIFF
--- a/site/blueprints/pages/emaj-essay.yml
+++ b/site/blueprints/pages/emaj-essay.yml
@@ -35,4 +35,16 @@ tabs:
             extends: fields/viewcount
           lastvisited:
             extends: fields/lastvisited
-  seo: seo/site
+    tools:
+      sections:
+        tools:
+          type: fields
+          fields:
+            exportDocx:
+              type: button
+              text: Download DOCX
+              icon: download
+              url: /download-docx/{{ page.id }}
+              open: true
+              theme: positive
+    seo: seo/site

--- a/site/blueprints/pages/essay.yml
+++ b/site/blueprints/pages/essay.yml
@@ -117,6 +117,13 @@ tabs:
             text: Check Chicago Manual of Style
             url: /check-style/{{ page.id }}
             theme: positive
+          exportDocx:
+            type: button
+            text: Download DOCX
+            icon: download
+            url: /download-docx/{{ page.id }}
+            open: true
+            theme: positive
           
   files:
     sections:

--- a/site/blueprints/pages/special-issue-essay.yml
+++ b/site/blueprints/pages/special-issue-essay.yml
@@ -137,6 +137,13 @@ tabs:
             text: Check Chicago Manual of Style
             url: /check-style/{{ page.id }}
             theme: positive
+          exportDocx:
+            type: button
+            text: Download DOCX
+            icon: download
+            url: /download-docx/{{ page.id }}
+            open: true
+            theme: positive
           
   analytics:
     sections:

--- a/site/plugins/docx-export/index.php
+++ b/site/plugins/docx-export/index.php
@@ -1,0 +1,67 @@
+<?php
+
+use Kirby\Cms\Response;
+
+Kirby::plugin('custom/docx-export', [
+    'routes' => [
+        [
+            'pattern' => 'download-docx/(:all)',
+            'method'  => 'GET',
+            'action'  => function (string $id) {
+                if (!kirby()->user()) {
+                    return new Response('Unauthorized', 'text/plain', 403);
+                }
+
+                if (!$page = page($id)) {
+                    return new Response('Page not found', 'text/plain', 404);
+                }
+
+                $allowed = ['essay', 'special-issue-essay', 'emaj-essay'];
+                if (!in_array($page->template()->name(), $allowed, true)) {
+                    return new Response('Invalid page type', 'text/plain', 400);
+                }
+
+                // Build HTML
+                $html = '<h1>' . $page->title()->esc() . '</h1>';
+                if ($page->subtitle()->isNotEmpty()) {
+                    $html .= '<h2>' . $page->subtitle()->kirbytextinline() . '</h2>';
+                }
+                if ($page->author()->isNotEmpty()) {
+                    $html .= '<p>' . $page->author()->esc() . '</p>';
+                }
+                $html .= $page->text()->kirbytext();
+                if ($page->bios()->isNotEmpty()) {
+                    $html .= '<div class="bios">' . $page->bios()->kirbytext() . '</div>';
+                }
+                if ($page->bibilography()->isNotEmpty()) {
+                    $html .= '<h2>Bibliography</h2>' . $page->bibilography()->kirbytext();
+                }
+                if ($page->selected_bibilography()->isNotEmpty()) {
+                    $html .= '<h2>Selected Bibliography</h2>';
+                    $html .= $page->headnote()->kirbytext();
+                    foreach ($page->selected_bibilography()->toStructure() as $section) {
+                        $html .= '<h3>' . $section->heading()->esc() . '</h3>';
+                        $html .= $section->bibliography()->kirbytext();
+                    }
+                }
+
+                $tmp = tempnam(sys_get_temp_dir(), 'docx');
+                $htmlFile = $tmp . '.html';
+                $docxFile = $tmp . '.docx';
+                file_put_contents($htmlFile, $html);
+
+                $cmd = 'pandoc ' . escapeshellarg($htmlFile) . ' -o ' . escapeshellarg($docxFile);
+                exec($cmd, $out, $ret);
+                if ($ret !== 0 || !file_exists($docxFile)) {
+                    return new Response('Error creating DOCX', 'text/plain', 500);
+                }
+
+                return Response::download(
+                    $docxFile,
+                    $page->slug() . '.docx',
+                    'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+                );
+            }
+        ]
+    ]
+]);


### PR DESCRIPTION
## Summary
- implement `download-docx` route to convert essay HTML to DOCX via pandoc
- add 'Download DOCX' panel button in essay blueprints

## Testing
- `php -l site/plugins/docx-export/index.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_683c0863df38833294227705adf08909