### PR TITLE
Add pandoc to Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ RUN apt-get update -o Acquire::ForceIPv4=true && apt-get install --no-install-re
     php-json \
     php-mbstring \
     php-xml \
-    php-zip && \
+    php-zip \
+    pandoc && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install imagemagick and utilities


### PR DESCRIPTION
## Summary
- add `pandoc` package to Dockerfile so plugins can invoke pandoc

## Testing
- `docker build -t test-image .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_683c09cf9a0c8332a9a47299cbdb3837