### PR TITLE
Restore essay PDF generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ RUN apt-get update -o Acquire::ForceIPv4=true && apt-get install --no-install-re
     php-json \
     php-mbstring \
     php-xml \
-    php-zip && \
+    php-zip \
+    chromium-browser && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install imagemagick and utilities


### PR DESCRIPTION
## Summary
- enable `output_pdf` hook
- add detection of Chrome/Chromium to produce PDFs
- install Chromium in Docker image

## Testing
- `npm run build` *(fails: EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_683c08fd06d8833281f78dd449ee8502