### PR TITLE
Enable code-based logins

### DIFF
--- a/site/config/config.php
+++ b/site/config/config.php
@@ -64,6 +64,10 @@ return [
 
   'panel.install' => true,
 
+  'auth' => [
+    'methods' => ['password', 'code']
+  ],
+
   'diesdasdigital.meta-knight' => [
     'siteTitleAfterPageTitle' => true,
   ],


### PR DESCRIPTION
## Summary
- allow login via code in the panel alongside passwords

## Testing
- `npm test` *(fails: Missing script)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683c0e4e14f483329bcc0af753d8154e