### PR TITLE
Add login email templates

### DIFF
--- a/site/templates/emails/auth/login.html.php
+++ b/site/templates/emails/auth/login.html.php
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Hi <?= $user->nameOrEmail() ?>,</p>
+<p>You recently requested a login code for <?= $site ?>.</p>
+<p style="font-size:1.5em;font-weight:bold;"><?= $code ?></p>
+<p>This code will be valid for <?= $timeout ?> minutes.</p>
+<p>If you did not request a login code, please ignore this email.</p>
+</body>
+</html>

--- a/site/templates/emails/auth/login.php
+++ b/site/templates/emails/auth/login.php
@@ -1,0 +1,16 @@
+<?php
+use Kirby\Toolkit\I18n;
+/**
+ * Plain text login code email
+ *
+ * @var Kirby\Cms\User $user
+ * @var string $site
+ * @var string $code
+ * @var int $timeout
+ */
+echo I18n::template(
+    'login.email.login.body',
+    null,
+    compact('user', 'site', 'code', 'timeout'),
+    $user->language()
+);

--- a/site/templates/emails/auth/password-reset.html.php
+++ b/site/templates/emails/auth/password-reset.html.php
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Hi <?= $user->nameOrEmail() ?>,</p>
+<p>You recently requested a password reset code for <?= $site ?>.</p>
+<p style="font-size:1.5em;font-weight:bold;"><?= $code ?></p>
+<p>This code will be valid for <?= $timeout ?> minutes.</p>
+<p>If you did not request a password reset code, please ignore this email.</p>
+</body>
+</html>

--- a/site/templates/emails/auth/password-reset.php
+++ b/site/templates/emails/auth/password-reset.php
@@ -1,0 +1,16 @@
+<?php
+use Kirby\Toolkit\I18n;
+/**
+ * Plain text password reset code email
+ *
+ * @var Kirby\Cms\User $user
+ * @var string $site
+ * @var string $code
+ * @var int $timeout
+ */
+echo I18n::template(
+    'login.email.password-reset.body',
+    null,
+    compact('user', 'site', 'code', 'timeout'),
+    $user->language()
+);


### PR DESCRIPTION
## Summary
- add HTML and text email templates for login code
- add HTML and text email templates for password reset code

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_b_683c10f86ab48332bd944da97af360a3