### PR TITLE
Update PHP requirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use latest offical ubuntu image
-FROM ubuntu:latest
+# Use PHP 8.4 with Apache as base image
+FROM php:8.4-apache
 
 # Set timezone environment variable
 ENV TZ=Australia/Melbourne
@@ -11,29 +11,24 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 # Remove annoying messages during package installation
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Install packages: web server Apache, PHP and extensions
+# Install packages and PHP extensions
 RUN apt-get update -o Acquire::ForceIPv4=true && apt-get install --no-install-recommends -y \
-    apache2 \
-    apache2-utils \
-    ca-certificates \
     git \
-    php \
-    libapache2-mod-php \
-    php-curl \
-    php-dom \
-    php-gd \
-    php-intl \
-    php-json \
-    php-mbstring \
-    php-xml \
-    php-zip \
-    pandoc && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    ca-certificates \
+    pandoc \
+    imagemagick \
+    && rm -rf /var/lib/apt/lists/*
 
-# Install imagemagick and utilities
-RUN apt-get update -o Acquire::ForceIPv4=true && \
-    apt-get install -y --no-install-recommends apt-utils imagemagick --fix-missing && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+# Install required PHP extensions
+RUN docker-php-ext-install \
+    curl \
+    dom \
+    gd \
+    intl \
+    mbstring \
+    xml \
+    zip
+
 # Copy virtual host configuration from current path onto existing 000-default.conf
 COPY default.conf /etc/apache2/sites-available/000-default.conf
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "source": "https://github.com/getkirby/starterkit"
   },
   "require": {
-    "php": ">= 8.2.0",
+    "php": ">= 8.4.0",
     "getkirby/cms": "^4.0",
     "johannschopplich/kirby-blurry-placeholder": "^2.0",
     "medienbaecker/autoresize": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -3095,7 +3095,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">= 8.2.0"
+        "php": ">= 8.4.0"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"

--- a/vendor/composer/platform_check.php
+++ b/vendor/composer/platform_check.php
@@ -4,8 +4,8 @@
 
 $issues = array();
 
-if (!(PHP_VERSION_ID >= 80200)) {
-    $issues[] = 'Your Composer dependencies require a PHP version ">= 8.2.0". You are running ' . PHP_VERSION . '.';
+if (!(PHP_VERSION_ID >= 80400)) {
+    $issues[] = 'Your Composer dependencies require a PHP version ">= 8.4.0". You are running ' . PHP_VERSION . '.';
 }
 
 if ($issues) {


### PR DESCRIPTION
## Summary
- upgrade base Dockerfile to use `php:8.4-apache`
- raise required PHP version to 8.4 in composer.json/lock
- update Composer platform check

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683cf73e8e5c8332b8cab6c4d079cd07