### PR TITLE
Fix Dockerfile PHP extension build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update -o Acquire::ForceIPv4=true && apt-get install --no-install-re
     libxml2-dev \
     libzip-dev \
     libicu-dev \
+    libonig-dev \
     libpng-dev \
     libjpeg-dev \
     libfreetype6-dev \


### PR DESCRIPTION
## Summary
- include `libonig-dev` so PHP's mbstring extension can build

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683d14a539d8833291e1f0aa6f2c5ff7