### PR TITLE
Add search controller and OpenSearch integration

### DIFF
--- a/site/blueprints/pages/search.yml
+++ b/site/blueprints/pages/search.yml
@@ -1,0 +1,10 @@
+title: Search
+icon: search
+options:
+  changeSlug: false
+  delete: false
+  changeStatus: false
+fields:
+  info:
+    type: info
+    text: Use the search page to find content.

--- a/site/config/config.php
+++ b/site/config/config.php
@@ -109,6 +109,14 @@ return [
 
   'routes' => [
     [
+      'pattern' => 'open-search.xml',
+      'action'  => function () {
+        $queryUrl = url('search') . '?q={searchTerms}';
+        $xml = snippet('opensearch', ['site' => site(), 'queryUrl' => $queryUrl], true);
+        return new Kirby\Cms\Response($xml, 'application/opensearchdescription+xml');
+      }
+    ],
+    [
       'pattern' => '/books/(:any)',
       'action'  => function ($uid) {
         return go("https://index-press.com/", 301);

--- a/site/controllers/search.php
+++ b/site/controllers/search.php
@@ -1,0 +1,74 @@
+<?php
+
+use Kirby\Toolkit\Str;
+
+return function ($site) {
+    $query = get('q');
+    $author = get('author');
+    $date = get('date');
+    $keywords = get('keywords');
+
+    $results = $site->index()->listed();
+
+    if ($author) {
+        $authorLower = Str::lower($author);
+        $results = $results->filter(function ($page) use ($authorLower) {
+            if ($page->author()->isNotEmpty() && Str::contains(Str::lower($page->author()->value()), $authorLower)) {
+                return true;
+            }
+            if ($page->authors()->isNotEmpty()) {
+                foreach ($page->authors()->yaml() as $a) {
+                    $name = strtolower(($a['first_name'] ?? '') . ' ' . ($a['last_name'] ?? ''));
+                    if (str_contains($name, $authorLower)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        });
+    }
+
+    if ($date) {
+        $results = $results->filter(function ($page) use ($date) {
+            $dates = [];
+            if ($page->date()->isNotEmpty()) {
+                $dates[] = $page->date()->toDate('Y-m-d');
+            }
+            if ($page->pub_date()->isNotEmpty()) {
+                $dates[] = $page->pub_date()->toDate('Y-m-d');
+            }
+            if ($page->parent() && $page->parent()->issue_date()->isNotEmpty()) {
+                $dates[] = $page->parent()->issue_date()->toDate('Y-m-d');
+            }
+            foreach ($dates as $d) {
+                if (Str::startsWith($d, $date)) {
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    if ($keywords) {
+        $filter = array_map('strtolower', Str::split($keywords));
+        $results = $results->filter(function ($page) use ($filter) {
+            $pageKeywords = array_map('strtolower', $page->keywords()->split(','));
+            return count(array_intersect($filter, $pageKeywords)) > 0;
+        });
+    }
+
+    if ($query) {
+        $results = $results->search($query, 'title|text|author|authors|keywords');
+    }
+
+    $results = $results->paginate(20);
+
+    return [
+        'query' => $query,
+        'results' => $results,
+        'pagination' => $results->pagination(),
+        'author' => $author,
+        'date' => $date,
+        'keywords' => $keywords
+    ];
+};

--- a/site/snippets/header.php
+++ b/site/snippets/header.php
@@ -7,6 +7,7 @@
 
   <!-- https://plugins.andkindness.com/seo/docs/get-started/installation-setup -->
   <?php snippet('seo/head'); ?>
+  <?= $page->meta()->opensearch() ?>
 
   <!-- Google Scholar -->
   <?php if ($page->template() == "essay") : ?>

--- a/site/snippets/opensearch.php
+++ b/site/snippets/opensearch.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @var Kirby\Cms\Site $site
+ * @var string $queryUrl
+ */
+?>
+<?='<?xml version="1.0" encoding="utf-8"?>'?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName><?= xml($site->title()) ?></ShortName>
+  <Description><?= xml($site->description()->or($site->title())) ?></Description>
+  <Url type="text/html" method="get" template="<?= xml($queryUrl) ?>"/>
+</OpenSearchDescription>

--- a/site/templates/search.php
+++ b/site/templates/search.php
@@ -1,0 +1,40 @@
+<?php snippet('header') ?>
+
+<form method="get" class="search-form">
+  <label>
+    Keywords
+    <input type="search" aria-label="Search" name="q" value="<?= html($query) ?>">
+  </label>
+  <label>
+    Author
+    <input type="text" name="author" value="<?= html($author ?? '') ?>">
+  </label>
+  <label>
+    Date
+    <input type="text" name="date" value="<?= html($date ?? '') ?>" placeholder="YYYY or YYYY-MM-DD">
+  </label>
+  <label>
+    Tags
+    <input type="text" name="keywords" value="<?= html($keywords ?? '') ?>">
+  </label>
+  <input type="submit" value="Search">
+</form>
+
+<ul>
+<?php foreach ($results as $result): ?>
+  <li><a href="<?= $result->url() ?>"><?= $result->title() ?></a></li>
+<?php endforeach ?>
+</ul>
+
+<?php if ($pagination->hasPages()): ?>
+<nav class="pagination">
+  <?php if ($pagination->hasPrevPage()): ?>
+    <a href="<?= $pagination->prevPageUrl() ?>">Previous</a>
+  <?php endif ?>
+  <?php if ($pagination->hasNextPage()): ?>
+    <a href="<?= $pagination->nextPageUrl() ?>">Next</a>
+  <?php endif ?>
+</nav>
+<?php endif ?>
+
+<?php snippet('footer') ?>


### PR DESCRIPTION
## Summary
- add search page controller with filtering
- create search template and blueprint
- expose search description via OpenSearch in the header
- route to serve `open-search.xml`

## Testing
- `composer validate --no-check-publish` *(fails: command not found)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6845328c7da883329a237c1d6c17eb3e