### PR TITLE
Simplify search UI

### DIFF
--- a/site/controllers/search.php
+++ b/site/controllers/search.php
@@ -1,74 +1,26 @@
 <?php
 
-use Kirby\Toolkit\Str;
 
 return function ($site) {
     $query = get('q');
-    $author = get('author');
-    $date = get('date');
-    $keywords = get('keywords');
-
-    $results = $site->index()->listed();
-
-    if ($author) {
-        $authorLower = Str::lower($author);
-        $results = $results->filter(function ($page) use ($authorLower) {
-            if ($page->author()->isNotEmpty() && Str::contains(Str::lower($page->author()->value()), $authorLower)) {
-                return true;
-            }
-            if ($page->authors()->isNotEmpty()) {
-                foreach ($page->authors()->yaml() as $a) {
-                    $name = strtolower(($a['first_name'] ?? '') . ' ' . ($a['last_name'] ?? ''));
-                    if (str_contains($name, $authorLower)) {
-                        return true;
-                    }
-                }
-            }
-            return false;
-        });
-    }
-
-    if ($date) {
-        $results = $results->filter(function ($page) use ($date) {
-            $dates = [];
-            if ($page->date()->isNotEmpty()) {
-                $dates[] = $page->date()->toDate('Y-m-d');
-            }
-            if ($page->pub_date()->isNotEmpty()) {
-                $dates[] = $page->pub_date()->toDate('Y-m-d');
-            }
-            if ($page->parent() && $page->parent()->issue_date()->isNotEmpty()) {
-                $dates[] = $page->parent()->issue_date()->toDate('Y-m-d');
-            }
-            foreach ($dates as $d) {
-                if (Str::startsWith($d, $date)) {
-                    return true;
-                }
-            }
-            return false;
-        });
-    }
-
-    if ($keywords) {
-        $filter = array_map('strtolower', Str::split($keywords));
-        $results = $results->filter(function ($page) use ($filter) {
-            $pageKeywords = array_map('strtolower', $page->keywords()->split(','));
-            return count(array_intersect($filter, $pageKeywords)) > 0;
-        });
-    }
 
     if ($query) {
-        $results = $results->search($query, 'title|text|author|authors|keywords');
+        $results = $site
+            ->index()
+            ->listed()
+            ->search($query, 'title|text|author|authors|keywords')
+            ->paginate(20);
+
+        return [
+            'query'      => $query,
+            'results'    => $results,
+            'pagination' => $results->pagination(),
+        ];
     }
 
-    $results = $results->paginate(20);
-
     return [
-        'query' => $query,
-        'results' => $results,
-        'pagination' => $results->pagination(),
-        'author' => $author,
-        'date' => $date,
-        'keywords' => $keywords
+        'query'      => $query,
+        'results'    => null,
+        'pagination' => null,
     ];
 };

--- a/site/templates/search.php
+++ b/site/templates/search.php
@@ -2,39 +2,29 @@
 
 <form method="get" class="search-form">
   <label>
-    Keywords
+    Search
     <input type="search" aria-label="Search" name="q" value="<?= html($query) ?>">
-  </label>
-  <label>
-    Author
-    <input type="text" name="author" value="<?= html($author ?? '') ?>">
-  </label>
-  <label>
-    Date
-    <input type="text" name="date" value="<?= html($date ?? '') ?>" placeholder="YYYY or YYYY-MM-DD">
-  </label>
-  <label>
-    Tags
-    <input type="text" name="keywords" value="<?= html($keywords ?? '') ?>">
   </label>
   <input type="submit" value="Search">
 </form>
 
-<ul>
-<?php foreach ($results as $result): ?>
-  <li><a href="<?= $result->url() ?>"><?= $result->title() ?></a></li>
-<?php endforeach ?>
-</ul>
+<?php if ($results): ?>
+  <ul>
+  <?php foreach ($results as $result): ?>
+    <li><a href="<?= $result->url() ?>"><?= $result->title() ?></a></li>
+  <?php endforeach ?>
+  </ul>
 
-<?php if ($pagination->hasPages()): ?>
-<nav class="pagination">
-  <?php if ($pagination->hasPrevPage()): ?>
-    <a href="<?= $pagination->prevPageUrl() ?>">Previous</a>
+  <?php if ($pagination && $pagination->hasPages()): ?>
+  <nav class="pagination">
+    <?php if ($pagination->hasPrevPage()): ?>
+      <a href="<?= $pagination->prevPageUrl() ?>">Previous</a>
+    <?php endif ?>
+    <?php if ($pagination->hasNextPage()): ?>
+      <a href="<?= $pagination->nextPageUrl() ?>">Next</a>
+    <?php endif ?>
+  </nav>
   <?php endif ?>
-  <?php if ($pagination->hasNextPage()): ?>
-    <a href="<?= $pagination->nextPageUrl() ?>">Next</a>
-  <?php endif ?>
-</nav>
 <?php endif ?>
 
 <?php snippet('footer') ?>


### PR DESCRIPTION
## Summary
- clean up search controller to use query only and return no results for empty search
- streamline search template to show only a query box and hide pagination without results

## Testing
- `npm run build` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68454bfae23c8332adb9f77a2626ccc5