### PR TITLE
Fix duplicate viewport tag

### DIFF
--- a/site/snippets/header.php
+++ b/site/snippets/header.php
@@ -48,7 +48,6 @@
   <?= js('assets/js/script.js?v=' . sha1_file('assets/js/script.js')) ?>
 
   <!-- google analytics -->
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="google-site-verification" content="REP3FyJ9Bqjr3A2K2owDTv9toyWnGTjnoPxmUs6vGT4" />
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-139982363-1"></script>
   <script>


### PR DESCRIPTION
## Summary
- keep only one viewport meta tag in header

## Testing
- `npm run build` *(fails: 403 Forbidden fetching tailwindcss)*

------
https://chatgpt.com/codex/tasks/task_b_68454c1399ec83328572bb6d98fe9748