### PR TITLE
Add DOAJ submission plugin

### DIFF
--- a/site/blueprints/pages/essay.yml
+++ b/site/blueprints/pages/essay.yml
@@ -1,5 +1,11 @@
 title: Essay
 
+buttons:
+  doaj:
+    icon: refresh
+    text: Submit to DOAJ
+    link: https://index-journal.org/submit-doaj/{{ page.id }}
+
 # icon: page
 # image:
 #   # query: false

--- a/site/config/config.php
+++ b/site/config/config.php
@@ -19,6 +19,8 @@ $base = dirname(__DIR__, 2);
 
 return [
   'url' => env('URL'),
+  'doaj.apiKey' => env('DOAJ_API_KEY'),
+  'doaj.apiUrl' => 'https://doaj.org/api/v2/articles',
 
   'ready' => function ($kirby) {
     return [

--- a/site/plugins/doaj-register/index.php
+++ b/site/plugins/doaj-register/index.php
@@ -1,0 +1,163 @@
+<?php
+
+use Kirby\Cms\Response;
+
+/**
+ * Read DOAJ-related config options.
+ */
+function doajOptions(): array
+{
+    return [
+        'apiUrl' => option('doaj.apiUrl', 'https://doaj.org/api/v2/articles'),
+        'apiKey' => option('doaj.apiKey'),
+    ];
+}
+
+/**
+ * Abort with 400 if required options are missing.
+ */
+function validateDoajSettings(array $opts): ?Response
+{
+    if (empty($opts['apiKey'])) {
+        return new Response('Missing DOAJ API key', 'text/plain', 400);
+    }
+    return null;
+}
+
+/**
+ * Kirby plugin.
+ */
+Kirby::plugin('custom/doaj-register', [
+    'snippets' => [
+        'doaj-confirm' => __DIR__ . '/snippets/confirm.php'
+    ],
+    'routes' => [
+        [
+            'pattern' => 'submit-doaj/(:all)',
+            'method'  => 'GET|POST',
+            'action'  => function (string $id) {
+
+                // 1. guards --------------------------------------------------
+                if (!kirby()->user()) {
+                    return new Response('Unauthorized', 'text/plain', 403);
+                }
+
+                if (!$essay = page($id)) {
+                    return new Response('Page not found', 'text/plain', 404);
+                }
+
+                if ($essay->template() !== 'essay') {
+                    return new Response('Invalid page type', 'text/plain', 400);
+                }
+
+                // 2. gather metadata ---------------------------------------
+                $data = collectDoajData($essay);
+
+                // 3. confirmation preview ---------------------------------
+                $request = kirby()->request();
+
+                if ($request->method() === 'GET' && $request->get('confirm') !== '1') {
+                    $html = snippet('doaj-confirm', [
+                        'essay' => $essay,
+                        'data'  => $data,
+                    ], true);
+                    return new Response($html, 'text/html');
+                }
+
+                // 4. reject POSTs without confirm=1 ------------------------
+                if ($request->method() === 'POST') {
+                    $confirm = $request->body()->get('confirm');
+                    if ($confirm !== '1') {
+                        return new Response('Confirmation required', 'text/plain', 400);
+                    }
+                }
+
+                // 5. send to DOAJ ------------------------------------------
+                $opts = doajOptions();
+                if ($resp = validateDoajSettings($opts)) {
+                    return $resp; // missing setting → abort
+                }
+
+                $result = sendToDoaj($data, $opts);
+                return new Response($result, 'application/json');
+            },
+        ],
+    ],
+]);
+
+/**
+ * Collect metadata for an essay page.
+ */
+function collectDoajData(Kirby\Cms\Page $essay): array
+{
+    $site  = kirby()->site();
+    $issue = $essay->parent();
+
+    $authors = [];
+    foreach ($essay->authors()->toStructure()->toArray() as $a) {
+        $name = trim(($a['first_name'] ?? '') . ' ' . ($a['last_name'] ?? ''));
+        if (!$name && isset($a['name'])) {
+            $name = $a['name'];
+        }
+        $authors[] = ['name' => $name];
+    }
+
+    $identifiers = [];
+    if ($essay->doi()->isNotEmpty()) {
+        $identifiers[] = ['type' => 'doi', 'id' => $essay->doi()->value()];
+    }
+
+    return [
+        'bibjson' => [
+            'title'  => $essay->title()->value(),
+            'journal' => [
+                'title' => $site->title()->value(),
+                'issn'  => $site->crossref_issn()->value(),
+            ],
+            'year'  => $issue->issue_date()->toDate('Y'),
+            'month' => $issue->issue_date()->toDate('m'),
+            'link'  => [
+                ['type' => 'fulltext', 'url' => $essay->url()],
+            ],
+            'identifier' => $identifiers,
+            'author' => $authors,
+            'abstract' => $essay->abstract()->value(),
+        ],
+    ];
+}
+
+/**
+ * Upload JSON to DOAJ and return a JSON string describing the outcome.
+ */
+function sendToDoaj(array $data, ?array $opt = null): string
+{
+    $opt ??= doajOptions();
+
+    $url    = $opt['apiUrl'] ?? 'https://doaj.org/api/v2/articles';
+    $apiKey = $opt['apiKey'] ?? '';
+
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_POST           => true,
+        CURLOPT_POSTFIELDS     => json_encode($data),
+        CURLOPT_HTTPHEADER     => [
+            'Content-Type: application/json',
+            'Authorization: Bearer ' . $apiKey,
+        ],
+        CURLOPT_HEADER         => true,
+    ]);
+    $raw  = curl_exec($ch);
+    $err  = curl_error($ch);
+    $info = curl_getinfo($ch);
+    curl_close($ch);
+
+    $headerSize = $info['header_size'] ?? 0;
+    $body       = substr($raw, $headerSize);
+
+    return json_encode([
+        'http_code'  => $info['http_code'] ?? 0,
+        'curl_error' => $err ?: null,
+        'body'       => $body ?: null,
+    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+}

--- a/site/plugins/doaj-register/snippets/confirm.php
+++ b/site/plugins/doaj-register/snippets/confirm.php
@@ -1,0 +1,45 @@
+<?php
+/** @var Kirby\Cms\Page $essay */
+/** @var array $data */
+?>
+<section>
+    <h1 style="font-size:1.5rem;margin-bottom:1rem">
+        Confirm DOAJ submission for “<?= html($data['bibjson']['title']) ?>”
+    </h1>
+    <ul>
+        <li><strong>DOI:</strong> <?= esc($data['bibjson']['identifier'][0]['id'] ?? '') ?></li>
+        <li><strong>Year:</strong> <?= esc($data['bibjson']['year'] ?? '') ?></li>
+        <li><strong>Month:</strong> <?= esc($data['bibjson']['month'] ?? '') ?></li>
+        <li><strong>URL:</strong> <a href="<?= esc($data['bibjson']['link'][0]['url'] ?? '') ?>"><?= esc($data['bibjson']['link'][0]['url'] ?? '') ?></a></li>
+        <li><strong>Journal:</strong> <?= esc($data['bibjson']['journal']['title'] ?? '') ?></li>
+        <li><strong>ISSN:</strong> <?= esc($data['bibjson']['journal']['issn'] ?? '') ?></li>
+    </ul>
+    <h2>Authors</h2>
+    <ul>
+        <?php foreach ($data['bibjson']['author'] as $a): ?>
+            <li><?= esc($a['name']) ?></li>
+        <?php endforeach ?>
+    </ul>
+    <?php if (!empty($data['bibjson']['abstract'])): ?>
+        <p><strong>Abstract:</strong> <?= esc($data['bibjson']['abstract']) ?></p>
+    <?php endif ?>
+    <form action="<?= url('submit-doaj/' . $essay->id()) ?>" method="post" style="display:flex;gap:.5rem;margin-top:2rem" id="doaj-submit-form">
+        <?= csrf() ?>
+        <input type="hidden" name="confirm" value="1">
+        <button type="submit" class="k-button k-button--filled" id="doaj-submit-btn">Confirm</button>
+        <a href="<?= $essay->panelUrl() ?>" class="k-button">Cancel</a>
+    </form>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            var form = document.getElementById('doaj-submit-form');
+            if (!form) return;
+            form.addEventListener('submit', function() {
+                var btn = document.getElementById('doaj-submit-btn');
+                if (btn) {
+                    btn.disabled = true;
+                    btn.textContent = 'Submitting…';
+                }
+            });
+        });
+    </script>
+</section>


### PR DESCRIPTION
## Summary
- add DOAJ config values and plugin
- allow essays to be submitted to DOAJ via new route
- expose a button in the essay blueprint

## Testing
- `npm test` *(fails: Missing script)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68455fb118a08332bbd1ccecb9e9b3a9