### PR TITLE
Add README for DOAJ plugin

### DIFF
--- a/site/plugins/doaj-register/README.md
+++ b/site/plugins/doaj-register/README.md
@@ -1,0 +1,24 @@
+# DOAJ Register
+
+This Kirby plugin submits metadata for an essay to the [Directory of Open Access Journals](https://doaj.org/).
+It collects the required fields from the page, shows a confirmation view and
+uploads the data to DOAJ's API when confirmed.
+
+## Usage
+
+1. Provide your DOAJ API key in `site/config/config.php`:
+
+```php
+return [
+    'doaj.apiKey' => env('DOAJ_API_KEY'),
+    // optional: 'doaj.apiUrl' => 'https://doaj.org/api/v2/articles'
+];
+```
+
+2. In the Panel open an essay and click **Submit to DOAJ**. Review the displayed
+   metadata and confirm the submission.
+
+The route `/submit-doaj/<page-id>` accepts `GET` and `POST` requests.
+`GET` renders the confirmation page; a `POST` with `confirm=1` performs the
+upload.
+


### PR DESCRIPTION
## Summary
- add documentation for the DOAJ metadata submission plugin

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684563d6c7a083328a0a9fff767847f8