### PR TITLE
Update DOAJ API integration

### DIFF
--- a/site/config/config.php
+++ b/site/config/config.php
@@ -20,7 +20,7 @@ $base = dirname(__DIR__, 2);
 return [
   'url' => env('URL'),
   'doaj.apiKey' => env('DOAJ_API_KEY'),
-  'doaj.apiUrl' => 'https://doaj.org/api/v2/articles',
+  'doaj.apiUrl' => 'https://doaj.org/api/articles',
 
   'ready' => function ($kirby) {
     return [

--- a/site/plugins/doaj-register/README.md
+++ b/site/plugins/doaj-register/README.md
@@ -11,7 +11,7 @@ uploads the data to DOAJ's API when confirmed.
 ```php
 return [
     'doaj.apiKey' => env('DOAJ_API_KEY'),
-    // optional: 'doaj.apiUrl' => 'https://doaj.org/api/v2/articles'
+    // optional: 'doaj.apiUrl' => 'https://doaj.org/api/articles'
 ];
 ```
 

--- a/site/plugins/doaj-register/index.php
+++ b/site/plugins/doaj-register/index.php
@@ -8,7 +8,7 @@ use Kirby\Cms\Response;
 function doajOptions(): array
 {
     return [
-        'apiUrl' => option('doaj.apiUrl', 'https://doaj.org/api/v2/articles'),
+        'apiUrl' => option('doaj.apiUrl', 'https://doaj.org/api/articles'),
         'apiKey' => option('doaj.apiKey'),
     ];
 }
@@ -133,8 +133,11 @@ function sendToDoaj(array $data, ?array $opt = null): string
 {
     $opt ??= doajOptions();
 
-    $url    = $opt['apiUrl'] ?? 'https://doaj.org/api/v2/articles';
+    $url    = $opt['apiUrl'] ?? 'https://doaj.org/api/articles';
     $apiKey = $opt['apiKey'] ?? '';
+
+    $querySep = str_contains($url, '?') ? '&' : '?';
+    $url .= $querySep . 'api_key=' . rawurlencode($apiKey);
 
     $ch = curl_init($url);
     curl_setopt_array($ch, [
@@ -143,7 +146,6 @@ function sendToDoaj(array $data, ?array $opt = null): string
         CURLOPT_POSTFIELDS     => json_encode($data),
         CURLOPT_HTTPHEADER     => [
             'Content-Type: application/json',
-            'Authorization: Bearer ' . $apiKey,
         ],
         CURLOPT_HEADER         => true,
     ]);


### PR DESCRIPTION
## Summary
- update DOAJ configuration to use API v4
- send api_key as a query parameter instead of auth header
- mention new API endpoint in README

## Testing
- `php -l site/plugins/doaj-register/index.php` *(fails: command not found)*
- `composer -V` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6845697629b08332b9e83cd5bc100240