### PR TITLE
Add DOAJ bulk submission support

### DIFF
--- a/site/blueprints/pages/issue.yml
+++ b/site/blueprints/pages/issue.yml
@@ -6,6 +6,10 @@ buttons:
     text: Submit to Crossref
     link: https://index-journal.org/submit-crossref/{{ page.id }}
     # theme: purple-icon
+  doaj:
+    icon: refresh
+    text: Submit DOAJ Batch
+    link: https://index-journal.org/submit-doaj-bulk/{{ page.id }}
   
 
 tabs:

--- a/site/blueprints/site.yml
+++ b/site/blueprints/site.yml
@@ -143,6 +143,11 @@ tabs:
             label: API Endpoint
             type: url
             default: https://doaj.org/api/articles
+
+          doaj_bulkApiUrl:
+            label: Bulk API Endpoint
+            type: url
+            default: https://doaj.org/api/v4/bulk/articles
           
 #  seotab: seo
   seo: seo/site

--- a/site/plugins/doaj-register/README.md
+++ b/site/plugins/doaj-register/README.md
@@ -16,3 +16,7 @@ The route `/submit-doaj/<page-id>` accepts `GET` and `POST` requests.
 `GET` renders the confirmation page; a `POST` with `confirm=1` performs the
 upload.
 
+To submit all essays of an issue at once, open an issue page in the Panel and
+click **Submit DOAJ Batch**. The route `/submit-doaj-bulk/<issue-id>` works the
+same way and uploads all descendant essays in one request using DOAJ's bulk API.
+

--- a/site/plugins/doaj-register/index.php
+++ b/site/plugins/doaj-register/index.php
@@ -9,8 +9,9 @@ function doajOptions(): array
 {
     $site = kirby()->site();
     return [
-        'apiUrl' => $site->doaj_apiUrl()->or('https://doaj.org/api/articles')->value(),
-        'apiKey' => $site->doaj_apiKey()->value(),
+        'apiUrl'      => $site->doaj_apiUrl()->or('https://doaj.org/api/articles')->value(),
+        'bulkApiUrl'  => $site->doaj_bulkApiUrl()->or('https://doaj.org/api/v4/bulk/articles')->value(),
+        'apiKey'      => $site->doaj_apiKey()->value(),
     ];
 }
 
@@ -30,7 +31,8 @@ function validateDoajSettings(array $opts): ?Response
  */
 Kirby::plugin('custom/doaj-register', [
     'snippets' => [
-        'doaj-confirm' => __DIR__ . '/snippets/confirm.php'
+        'doaj-confirm' => __DIR__ . '/snippets/confirm.php',
+        'doaj-confirm-bulk' => __DIR__ . '/snippets/confirm-bulk.php'
     ],
     'routes' => [
         [
@@ -92,6 +94,61 @@ Kirby::plugin('custom/doaj-register', [
                         }
                     }
                 }
+
+                return new Response($result, 'application/json');
+            },
+        ],
+        [
+            'pattern' => 'submit-doaj-bulk/(:all)',
+            'method'  => 'GET|POST',
+            'action'  => function (string $id) {
+
+                // 1. guards --------------------------------------------------
+                if (!kirby()->user()) {
+                    return new Response('Unauthorized', 'text/plain', 403);
+                }
+
+                if (!$issue = page($id)) {
+                    return new Response('Issue not found', 'text/plain', 404);
+                }
+
+                if ($issue->template() != 'issue') {
+                    return new Response('Invalid page type (' . $issue->template() . ')', 'text/plain', 400);
+                }
+
+                // 2. gather metadata ---------------------------------------
+                $essays = kirby()->site()->index()
+                    ->filterBy('template', 'essay')
+                    ->filter(fn($c) => $c->isDescendantOf($issue));
+
+                $articles = array_map(fn($e) => collectDoajData($e), $essays->values());
+
+                // 3. confirmation preview ---------------------------------
+                $request = kirby()->request();
+
+                if ($request->method() === 'GET' && $request->get('confirm') !== '1') {
+                    $html = snippet('doaj-confirm-bulk', [
+                        'issue'    => $issue,
+                        'articles' => $articles,
+                    ], true);
+                    return new Response($html, 'text/html');
+                }
+
+                // 4. reject POSTs without confirm=1 ------------------------
+                if ($request->method() === 'POST') {
+                    $confirm = $request->body()->get('confirm');
+                    if ($confirm !== '1') {
+                        return new Response('Confirmation required', 'text/plain', 400);
+                    }
+                }
+
+                // 5. send to DOAJ ------------------------------------------
+                $opts = doajOptions();
+                if ($resp = validateDoajSettings($opts)) {
+                    return $resp; // missing setting → abort
+                }
+
+                $result = sendBulkToDoaj($articles, $opts);
 
                 return new Response($result, 'application/json');
             },
@@ -162,6 +219,54 @@ function sendToDoaj(array $data, ?array $opt = null): string
         CURLOPT_RETURNTRANSFER => true,
         CURLOPT_POST           => true,
         CURLOPT_POSTFIELDS     => json_encode($data),
+        CURLOPT_HTTPHEADER     => [
+            'Content-Type: application/json',
+        ],
+        CURLOPT_HEADER         => true,
+    ]);
+    $raw  = curl_exec($ch);
+    $err  = curl_error($ch);
+    $info = curl_getinfo($ch);
+    curl_close($ch);
+
+    $headerSize = $info['header_size'] ?? 0;
+    $body       = substr($raw, $headerSize);
+
+    return json_encode([
+        'http_code'  => $info['http_code'] ?? 0,
+        'curl_error' => $err ?: null,
+        'body'       => $body ?: null,
+    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+}
+
+/**
+ * Upload multiple articles to DOAJ and return a JSON string describing the outcome.
+ */
+function sendBulkToDoaj(array $articles, ?array $opt = null): string
+{
+    $opt ??= doajOptions();
+
+    // derive bulk endpoint from single apiUrl if no explicit option
+    $url = $opt['bulkApiUrl'] ?? null;
+    if (!$url) {
+        $base = $opt['apiUrl'] ?? 'https://doaj.org/api/articles';
+        $url = preg_replace('#/articles$#', '/bulk/articles', $base);
+        if ($url === null) {
+            $url = 'https://doaj.org/api/v4/bulk/articles';
+        }
+    }
+    $apiKey = $opt['apiKey'] ?? '';
+
+    $querySep = str_contains($url, '?') ? '&' : '?';
+    $url .= $querySep . 'api_key=' . rawurlencode($apiKey);
+
+    $payload = ['articles' => $articles];
+
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_POST           => true,
+        CURLOPT_POSTFIELDS     => json_encode($payload),
         CURLOPT_HTTPHEADER     => [
             'Content-Type: application/json',
         ],

--- a/site/plugins/doaj-register/snippets/confirm-bulk.php
+++ b/site/plugins/doaj-register/snippets/confirm-bulk.php
@@ -1,0 +1,51 @@
+<?php
+/** @var Kirby\Cms\Page $issue */
+/** @var array $articles */
+?>
+<section>
+    <h1 style="font-size:1.5rem;margin-bottom:1rem">
+        Confirm DOAJ bulk submission for “<?= html($issue->title()) ?>”
+    </h1>
+    <p><?= count($articles) ?> article(s) will be submitted.</p>
+    <?php foreach ($articles as $data): ?>
+        <details style="margin-bottom:1rem">
+            <summary style="cursor:pointer">
+                <strong><?= esc($data['bibjson']['title'] ?? '') ?></strong>
+                <?php
+                    $doi = '';
+                    foreach (($data['bibjson']['identifier'] ?? []) as $id) {
+                        if (($id['type'] ?? '') === 'doi') {
+                            $doi = $id['id'];
+                            break;
+                        }
+                    }
+                    if ($doi): ?>
+                        (<?= esc($doi) ?>)
+                <?php endif; ?>
+            </summary>
+            <div style="padding-left:1rem">
+                <p><strong>URL:</strong> <a href="<?= esc($data['bibjson']['link'][0]['url'] ?? '') ?>"><?= esc($data['bibjson']['link'][0]['url'] ?? '') ?></a></p>
+                <p><strong>Year:</strong> <?= esc($data['bibjson']['year'] ?? '') ?></p>
+            </div>
+        </details>
+    <?php endforeach ?>
+    <form action="<?= url('submit-doaj-bulk/' . $issue->id()) ?>" method="post" style="display:flex;gap:.5rem;margin-top:2rem" id="doaj-bulk-submit-form">
+        <?= csrf() ?>
+        <input type="hidden" name="confirm" value="1">
+        <button type="submit" class="k-button k-button--filled" id="doaj-bulk-submit-btn">Confirm</button>
+        <a href="<?= $issue->panelUrl() ?>" class="k-button">Cancel</a>
+    </form>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            var form = document.getElementById('doaj-bulk-submit-form');
+            if (!form) return;
+            form.addEventListener('submit', function() {
+                var btn = document.getElementById('doaj-bulk-submit-btn');
+                if (btn) {
+                    btn.disabled = true;
+                    btn.textContent = 'Submitting…';
+                }
+            });
+        });
+    </script>
+</section>


### PR DESCRIPTION
## Summary
- extend DOAJ plugin with bulk submission endpoint and helper
- add confirmation view for issue bulk submission
- expose bulk endpoint setting
- allow submitting issues to DOAJ from the panel
- document new behaviour

## Testing
- `npm run build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tailwindcss)*

------
https://chatgpt.com/codex/tasks/task_b_684661a583a883329cf7ca17fe6c04b5