### PR TITLE
Show DOAJ diffs before submitting

### DIFF
--- a/site/plugins/doaj-register/index.php
+++ b/site/plugins/doaj-register/index.php
@@ -207,7 +207,7 @@ Kirby::plugin('custom/doaj-register', [
                     $html .= '<li><strong>Status URL:</strong> <a href="' . htmlspecialchars($body['status']) . '" target="_blank">' . htmlspecialchars($body['status']) . '</a></li>';
                     $html .= '</ul>';
                     $html .= '<p>You can check this link in a few minutes to track the progress of your submission.</p>';
-                    $html .= '<pre>' . $body . '</pre>';
+                    // $html .= '<pre>' . $body . '</pre>';
                     return new Response($html, 'text/html');
                 } else {
                     return new Response('<pre>' . htmlspecialchars($result) . '</pre>', 'text/html');

--- a/site/plugins/doaj-register/snippets/confirm-bulk.php
+++ b/site/plugins/doaj-register/snippets/confirm-bulk.php
@@ -2,31 +2,83 @@
 
 /** @var Kirby\Cms\Page $issue */
 /** @var array $articles */
+
+$getDoi = function ($bib) {
+    foreach (($bib['identifier'] ?? []) as $id) {
+        if (($id['type'] ?? '') === 'doi') {
+            return $id['id'];
+        }
+    }
+    return '';
+};
+
+$getAuthors = function ($bib) {
+    $names = [];
+    foreach (($bib['author'] ?? []) as $a) {
+        if (!empty($a['name'])) {
+            $names[] = $a['name'];
+        }
+    }
+    return implode('; ', $names);
+};
+
+$getUrl = fn($bib) => $bib['link'][0]['url'] ?? '';
+
+$fields = [
+    'Title'   => fn($b) => $b['title'] ?? '',
+    'DOI'     => $getDoi,
+    'Year'    => fn($b) => $b['year'] ?? '',
+    'Month'   => fn($b) => $b['month'] ?? '',
+    'URL'     => $getUrl,
+    'Journal' => fn($b) => $b['journal']['title'] ?? '',
+    'ISSN'    => fn($b) => $b['journal']['issn'] ?? '',
+    'Authors' => $getAuthors,
+    'Abstract'=> fn($b) => $b['abstract'] ?? '',
+];
 ?>
 <section>
     <h1 style="font-size:1.5rem;margin-bottom:1rem">
         Confirm DOAJ bulk submission for “<?= html($issue->title()) ?>”
     </h1>
     <p><?= count($articles) ?> article(s) will be submitted.</p>
-    <?php foreach ($articles as $data): ?>
+    <?php foreach ($articles as $article):
+        $data = $article['data'];
+        $existing = $article['existing'];
+        $existingBib = $existing['bibjson'] ?? null;
+        $doi = $getDoi($data['bibjson']);
+    ?>
         <details style="margin-bottom:1rem">
             <summary style="cursor:pointer">
                 <strong><?= esc($data['bibjson']['title'] ?? '') ?></strong>
-                <?php
-                $doi = '';
-                foreach (($data['bibjson']['identifier'] ?? []) as $id) {
-                    if (($id['type'] ?? '') === 'doi') {
-                        $doi = $id['id'];
-                        break;
-                    }
-                }
-                if ($doi): ?>
-                    (<?= esc($doi) ?>)
-                <?php endif; ?>
+                <?php if ($doi): ?>(<?= esc($doi) ?>)<?php endif ?>
             </summary>
             <div style="padding-left:1rem">
-                <p><strong>URL:</strong> <a href="<?= esc($data['bibjson']['link'][0]['url'] ?? '') ?>"><?= esc($data['bibjson']['link'][0]['url'] ?? '') ?></a></p>
-                <p><strong>Year:</strong> <?= esc($data['bibjson']['year'] ?? '') ?></p>
+                <table style="border-collapse:collapse;margin:0.5rem 0;width:100%">
+                    <thead>
+                        <tr>
+                            <th style="text-align:left">Field</th>
+                            <?php if ($existingBib): ?>
+                                <th style="text-align:left">Current</th>
+                            <?php endif ?>
+                            <th style="text-align:left">New</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($fields as $label => $fn):
+                            $new = $fn($data['bibjson']);
+                            $old = $existingBib ? $fn($existingBib) : '';
+                            $changed = $existingBib && $old !== $new;
+                        ?>
+                            <tr<?= $changed ? ' style="background:#ffe6e6"' : '' ?>>
+                                <td><strong><?= esc($label) ?></strong></td>
+                                <?php if ($existingBib): ?>
+                                    <td><?= esc($old) ?></td>
+                                <?php endif ?>
+                                <td><?= esc($new) ?></td>
+                            </tr>
+                        <?php endforeach ?>
+                    </tbody>
+                </table>
             </div>
         </details>
     <?php endforeach ?>
@@ -37,7 +89,7 @@
         <a href="<?= $issue->panelUrl() ?>" class="k-button">Cancel</a>
     </form>
     <h2>Preview DOAJ Payload</h2>
-    <pre><?= json_encode($articles, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) ?></pre>
+    <pre><?= json_encode(array_column($articles, 'data'), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) ?></pre>
 
 
     <script>

--- a/site/plugins/doaj-register/snippets/confirm-bulk.php
+++ b/site/plugins/doaj-register/snippets/confirm-bulk.php
@@ -31,9 +31,18 @@ $fields = [
     'Month'   => fn($b) => $b['month'] ?? '',
     'URL'     => $getUrl,
     'Journal' => fn($b) => $b['journal']['title'] ?? '',
-    'ISSN'    => fn($b) => $b['journal']['issn'] ?? '',
+    'ISSN' => fn($b) => (
+        function ($ids) {
+            foreach ($ids ?? [] as $id) {
+                if (($id['type'] ?? '') === 'eissn') {
+                    return $id['id'];
+                }
+            }
+            return '';
+        }
+    )($b['identifier'] ?? []),
     'Authors' => $getAuthors,
-    'Abstract'=> fn($b) => $b['abstract'] ?? '',
+    'Abstract' => fn($b) => $b['abstract'] ?? '',
 ];
 ?>
 <section>
@@ -75,8 +84,8 @@ $fields = [
                                     <td><?= esc($old) ?></td>
                                 <?php endif ?>
                                 <td><?= esc($new) ?></td>
-                            </tr>
-                        <?php endforeach ?>
+                                </tr>
+                            <?php endforeach ?>
                     </tbody>
                 </table>
             </div>

--- a/site/plugins/doaj-register/snippets/confirm.php
+++ b/site/plugins/doaj-register/snippets/confirm.php
@@ -2,28 +2,73 @@
 
 /** @var Kirby\Cms\Page $essay */
 /** @var array $data */
+/** @var array|null $existing */
+
+$existingBib = $existing['bibjson'] ?? null;
+
+$getDoi = function ($bib) {
+    foreach (($bib['identifier'] ?? []) as $id) {
+        if (($id['type'] ?? '') === 'doi') {
+            return $id['id'];
+        }
+    }
+    return '';
+};
+
+$getAuthors = function ($bib) {
+    $names = [];
+    foreach (($bib['author'] ?? []) as $a) {
+        if (!empty($a['name'])) {
+            $names[] = $a['name'];
+        }
+    }
+    return implode('; ', $names);
+};
+
+$getUrl = fn($bib) => $bib['link'][0]['url'] ?? '';
+
+$fields = [
+    'Title'   => fn($b) => $b['title'] ?? '',
+    'DOI'     => $getDoi,
+    'Year'    => fn($b) => $b['year'] ?? '',
+    'Month'   => fn($b) => $b['month'] ?? '',
+    'URL'     => $getUrl,
+    'Journal' => fn($b) => $b['journal']['title'] ?? '',
+    'ISSN'    => fn($b) => $b['journal']['issn'] ?? '',
+    'Authors' => $getAuthors,
+    'Abstract'=> fn($b) => $b['abstract'] ?? '',
+];
 ?>
 <section>
     <h1 style="font-size:1.5rem;margin-bottom:1rem">
         Confirm DOAJ submission for “<?= html($data['bibjson']['title']) ?>”
     </h1>
-    <ul>
-        <li><strong>DOI:</strong> <?= esc($data['bibjson']['identifier'][0]['id'] ?? '') ?></li>
-        <li><strong>Year:</strong> <?= esc($data['bibjson']['year'] ?? '') ?></li>
-        <li><strong>Month:</strong> <?= esc($data['bibjson']['month'] ?? '') ?></li>
-        <li><strong>URL:</strong> <a href="<?= esc($data['bibjson']['link'][0]['url'] ?? '') ?>"><?= esc($data['bibjson']['link'][0]['url'] ?? '') ?></a></li>
-        <li><strong>Journal:</strong> <?= esc($data['bibjson']['journal']['title'] ?? '') ?></li>
-        <li><strong>ISSN:</strong> <?= esc($data['bibjson']['journal']['issn'] ?? '') ?></li>
-    </ul>
-    <h2>Authors</h2>
-    <ul>
-        <?php foreach ($data['bibjson']['author'] as $a): ?>
-            <li><?= esc($a['name']) ?></li>
-        <?php endforeach ?>
-    </ul>
-    <?php if (!empty($data['bibjson']['abstract'])): ?>
-        <p><strong>Abstract:</strong> <?= esc($data['bibjson']['abstract']) ?></p>
-    <?php endif ?>
+    <table style="border-collapse:collapse;margin-bottom:1rem;width:100%">
+        <thead>
+            <tr>
+                <th style="text-align:left">Field</th>
+                <?php if ($existingBib): ?>
+                    <th style="text-align:left">Current</th>
+                <?php endif ?>
+                <th style="text-align:left">New</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($fields as $label => $fn):
+                $new = $fn($data['bibjson']);
+                $old = $existingBib ? $fn($existingBib) : '';
+                $changed = $existingBib && $old !== $new;
+            ?>
+                <tr<?= $changed ? ' style="background:#ffe6e6"' : '' ?>>
+                    <td><strong><?= esc($label) ?></strong></td>
+                    <?php if ($existingBib): ?>
+                        <td><?= esc($old) ?></td>
+                    <?php endif ?>
+                    <td><?= esc($new) ?></td>
+                </tr>
+            <?php endforeach ?>
+        </tbody>
+    </table>
     <form action="<?= url('submit-doaj/' . $essay->id()) ?>" method="post" style="display:flex;gap:.5rem;margin-top:2rem" id="doaj-submit-form">
         <?= csrf() ?>
         <input type="hidden" name="confirm" value="1">

--- a/site/plugins/doaj-register/snippets/confirm.php
+++ b/site/plugins/doaj-register/snippets/confirm.php
@@ -34,9 +34,18 @@ $fields = [
     'Month'   => fn($b) => $b['month'] ?? '',
     'URL'     => $getUrl,
     'Journal' => fn($b) => $b['journal']['title'] ?? '',
-    'ISSN'    => fn($b) => $b['journal']['issn'] ?? '',
+    'ISSN' => fn($b) => (
+        function ($ids) {
+            foreach ($ids ?? [] as $id) {
+                if (($id['type'] ?? '') === 'eissn') {
+                    return $id['id'];
+                }
+            }
+            return '';
+        }
+    )($b['identifier'] ?? []),
     'Authors' => $getAuthors,
-    'Abstract'=> fn($b) => $b['abstract'] ?? '',
+    'Abstract' => fn($b) => $b['abstract'] ?? '',
 ];
 ?>
 <section>
@@ -65,8 +74,8 @@ $fields = [
                         <td><?= esc($old) ?></td>
                     <?php endif ?>
                     <td><?= esc($new) ?></td>
-                </tr>
-            <?php endforeach ?>
+                    </tr>
+                <?php endforeach ?>
         </tbody>
     </table>
     <form action="<?= url('submit-doaj/' . $essay->id()) ?>" method="post" style="display:flex;gap:.5rem;margin-top:2rem" id="doaj-submit-form">


### PR DESCRIPTION
## Summary
- compare local DOAJ payload with existing record if available
- show diff table when submitting a single article
- show full details and diff for every article in bulk confirm
- include DOAJ fetch helper

## Testing
- `npm run build` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6846746f3c1083329e21d05307f78709