### PR TITLE
Refactor OAI endpoint as plugin

### DIFF
--- a/site/blueprints/pages/emaj-essay.yml
+++ b/site/blueprints/pages/emaj-essay.yml
@@ -31,6 +31,39 @@ tabs:
           bios:
             label: Bio/s
             type: textarea
+          pub_date:
+            label: Publication Date
+            type: date
+            width: 1/2
+          publisher:
+            label: Publisher
+            type: text
+            default: Index Journal
+            width: 1/2
+          article_type:
+            label: Type
+            type: select
+            default: ScholarlyArticle
+            options:
+              - Text
+              - Article
+              - ScholarlyArticle
+          language:
+            label: Language
+            type: text
+            default: en
+            width: 1/2
+          rights:
+            label: Rights
+            type: select
+            default: CC BY-NC-ND 4.0
+            options:
+              - CC BY 4.0
+              - CC BY-SA 4.0
+              - CC BY-ND 4.0
+              - CC BY-NC 4.0
+              - CC BY-NC-SA 4.0
+              - CC BY-NC-ND 4.0
           viewcount:
             extends: fields/viewcount
           lastvisited:

--- a/site/blueprints/pages/essay.yml
+++ b/site/blueprints/pages/essay.yml
@@ -93,6 +93,39 @@ tabs:
             label: Bio/s
             type: textarea
             # width: 1/2
+          pub_date:
+            label: Publication Date
+            type: date
+            width: 1/2
+          publisher:
+            label: Publisher
+            type: text
+            default: Index Journal
+            width: 1/2
+          article_type:
+            label: Type
+            type: select
+            default: ScholarlyArticle
+            options:
+              - Text
+              - Article
+              - ScholarlyArticle
+          language:
+            label: Language
+            type: text
+            default: en
+            width: 1/2
+          rights:
+            label: Rights
+            type: select
+            default: CC BY-NC-ND 4.0
+            options:
+              - CC BY 4.0
+              - CC BY-SA 4.0
+              - CC BY-ND 4.0
+              - CC BY-NC 4.0
+              - CC BY-NC-SA 4.0
+              - CC BY-NC-ND 4.0
           
 
   bibliography:

--- a/site/blueprints/pages/special-issue-essay.yml
+++ b/site/blueprints/pages/special-issue-essay.yml
@@ -76,6 +76,39 @@ tabs:
             label: Bio/s
             type: textarea
             # width: 1/2
+          pub_date:
+            label: Publication Date
+            type: date
+            width: 1/2
+          publisher:
+            label: Publisher
+            type: text
+            default: Index Journal
+            width: 1/2
+          article_type:
+            label: Type
+            type: select
+            default: ScholarlyArticle
+            options:
+              - Text
+              - Article
+              - ScholarlyArticle
+          language:
+            label: Language
+            type: text
+            default: en
+            width: 1/2
+          rights:
+            label: Rights
+            type: select
+            default: CC BY-NC-ND 4.0
+            options:
+              - CC BY 4.0
+              - CC BY-SA 4.0
+              - CC BY-ND 4.0
+              - CC BY-NC 4.0
+              - CC BY-NC-SA 4.0
+              - CC BY-NC-ND 4.0
           
 
   bibliography:

--- a/site/config/config.php
+++ b/site/config/config.php
@@ -139,13 +139,6 @@ return [
         return new Kirby\Cms\Response(citationRis($page), 'application/x-research-info-systems');
       }
     ],
-    [
-      'pattern' => 'oai',
-      'action'  => function () {
-        $xml = snippet('oai', [], true);
-        return new Kirby\Cms\Response($xml, 'text/xml');
-      }
-    ],
 
   ],
 

--- a/site/plugins/oai-endpoint/index.php
+++ b/site/plugins/oai-endpoint/index.php
@@ -1,0 +1,18 @@
+<?php
+
+use Kirby\Cms\Response;
+
+Kirby::plugin('custom/oai-endpoint', [
+    'snippets' => [
+        'oai' => __DIR__ . '/snippets/oai.php'
+    ],
+    'routes' => [
+        [
+            'pattern' => 'oai',
+            'action'  => function () {
+                $xml = snippet('oai', [], true);
+                return new Response($xml, 'text/xml');
+            }
+        ]
+    ]
+]);

--- a/site/plugins/oai-endpoint/snippets/oai.php
+++ b/site/plugins/oai-endpoint/snippets/oai.php
@@ -16,6 +16,12 @@ foreach ($issues as $issue) {
         'doi'      => $issue->issue_doi()->value(),
         'abstract' => null,
         'url'      => $issue->url(),
+        'subject'  => $issue->keywords()->value(),
+        'publisher'=> 'Index Journal',
+        'pubDate'  => $issue->issue_date()->toDate('Y-m-d'),
+        'type'     => 'Issue',
+        'language' => 'en',
+        'rights'   => 'CC BY-NC-ND 4.0',
     ];
 
     foreach ($issue->index()->filterBy('template', 'essay') as $essay) {
@@ -31,6 +37,12 @@ foreach ($issues as $issue) {
             'doi'      => $essay->doi()->value(),
             'abstract' => $essay->abstract()->value(),
             'url'      => $essay->url(),
+            'subject'  => $essay->keywords()->value(),
+            'publisher'=> $essay->publisher()->or('Index Journal')->value(),
+            'pubDate'  => $essay->parent()->issue_date()->toDate('Y-m-d'),
+            'type'     => $essay->article_type()->or('ScholarlyArticle')->value(),
+            'language' => $essay->language()->or('en')->value(),
+            'rights'   => $essay->rights()->or('CC BY-NC-ND 4.0')->value(),
         ];
     }
 }
@@ -57,6 +69,14 @@ foreach ($issues as $issue) {
 <?php foreach ($r['creators'] as $c): ?>
                     <dc:creator><?= esc($c) ?></dc:creator>
 <?php endforeach; ?>
+<?php if (!empty($r['subject'])): ?>
+                    <dc:subject><?= esc($r['subject']) ?></dc:subject>
+<?php endif; ?>
+                    <dc:publisher><?= esc($r['publisher']) ?></dc:publisher>
+                    <dc:date><?= esc($r['pubDate']) ?></dc:date>
+                    <dc:type><?= esc($r['type']) ?></dc:type>
+                    <dc:language><?= esc($r['language']) ?></dc:language>
+                    <dc:rights><?= esc($r['rights']) ?></dc:rights>
 <?php if (!empty($r['abstract'])): ?>
                     <dc:description><?= esc($r['abstract']) ?></dc:description>
 <?php endif; ?>

--- a/site/snippets/header.php
+++ b/site/snippets/header.php
@@ -9,7 +9,7 @@
   <?php snippet('seo/head'); ?>
 
   <!-- oai -->
-  <link rel="alternate" type="application/oaipmh+xml" href="https://index-journal.org/oai" title="OAI-PMH" />
+  <link rel="alternate" type="application/oaipmh+xml" href="<?= url('oai') ?>" title="OAI-PMH" />
 
 
   <!-- Google Scholar -->

--- a/site/templates/emaj-essay.php
+++ b/site/templates/emaj-essay.php
@@ -47,6 +47,9 @@
             <a href="<?= url('citation/bibtex/' . $page->id()) ?>">BibTeX</a> |
             <a href="<?= url('citation/ris/' . $page->id()) ?>">RIS</a>
           </span>
+          <?php if ($page->rights()->isNotEmpty()) : ?>
+            <span class="rights"><?= $page->rights() ?></span>
+          <?php endif ?>
         </span>
       <?php endif ?>
     </footer>

--- a/site/templates/essay.php
+++ b/site/templates/essay.php
@@ -83,6 +83,9 @@
             <a href="<?= url('citation/bibtex/' . $page->id()) ?>">BibTeX</a> |
             <a href="<?= url('citation/ris/' . $page->id()) ?>">RIS</a>
           </span>
+          <?php if ($page->rights()->isNotEmpty()) : ?>
+            <span class="rights"><?= $page->rights() ?></span>
+          <?php endif ?>
         </span>
       <?php endif ?>
     </footer>

--- a/site/templates/special-issue-essay.php
+++ b/site/templates/special-issue-essay.php
@@ -83,6 +83,9 @@
             <a href="<?= url('citation/bibtex/' . $page->id()) ?>">BibTeX</a> |
             <a href="<?= url('citation/ris/' . $page->id()) ?>">RIS</a>
           </span>
+          <?php if ($page->rights()->isNotEmpty()) : ?>
+            <span class="rights"><?= $page->rights() ?></span>
+          <?php endif ?>
         </span>
       <?php endif ?>
     </footer>


### PR DESCRIPTION
## Summary
- move OAI endpoint and XML snippet into a dedicated plugin
- add publication metadata fields to essay blueprints
- expose license info on essay templates
- provide dynamic OAI link

## Testing
- `npm run build` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6846837c9d088332842619f416f7be77