### PR TITLE
Integrate base styles into Tailwind

### DIFF
--- a/site/snippets/header.php
+++ b/site/snippets/header.php
@@ -95,8 +95,8 @@
 </head>
 
 <body data-display="<?= $page->template() ?>">
-  <header class="flex justify-between fixed left-0 w-screen p-4 bg-white shadow-[0px_15px_16px_0px_rgba(255,255,255,1)] transition z-10" style="top: var(--admin-bar--height, 0);<?php if ($page->template() == 'essay') : ?> background-color: rgb(<?= $page->parent()->issue_color() ?>); box-shadow: 0px 11px 16px 0px rgba(<?= $page->parent()->issue_color() ?>);<?php endif ?>">
-    <h1>
+  <header class="flex justify-between fixed left-0 w-screen p-4 bg-white shadow-[0px_15px_16px_0px_rgba(255,255,255,1)] transition z-10 font-sans" style="top: var(--admin-bar--height, 0);<?php if ($page->template() == 'essay') : ?> background-color: rgb(<?= $page->parent()->issue_color() ?>); box-shadow: 0px 11px 16px 0px rgba(<?= $page->parent()->issue_color() ?>);<?php endif ?>">
+    <h1 class="font-sans">
       <a href="<?= $site->url() ?>">INDEX JOURNAL</a>
 
 

--- a/site/snippets/menu-pane.php
+++ b/site/snippets/menu-pane.php
@@ -1,7 +1,7 @@
-<section class="menu-pane fixed top-0 left-0 w-screen z-[1000] p-4 bg-white shadow-[0px_15px_16px_0px_rgba(255,255,255,1)] overflow-scroll transition" <?php if ($page->template() == 'essay') : ?>style="background-color: rgb(<?= $page->parent()->issue_color() ?>); box-shadow: 0px 15px 16px 0px rgba(<?= $page->parent()->issue_color() ?>);" <?php endif ?><?php if ($page->template() == 'product') : ?> style="background-color: <?= $page->color() ?>; box-shadow: 0px 15px 16px 0px <?= $page->color() ?>;" <?php endif ?>>
-    <h1 class="close">(close)</h1>
+<section class="menu-pane fixed top-0 left-0 w-screen z-[1000] p-4 bg-white shadow-[0px_15px_16px_0px_rgba(255,255,255,1)] overflow-scroll transition hidden" <?php if ($page->template() == 'essay') : ?>style="background-color: rgb(<?= $page->parent()->issue_color() ?>); box-shadow: 0px 15px 16px 0px rgba(<?= $page->parent()->issue_color() ?>);" <?php endif ?><?php if ($page->template() == 'product') : ?> style="background-color: <?= $page->color() ?>; box-shadow: 0px 15px 16px 0px <?= $page->color() ?>;" <?php endif ?>>
+    <h1 class="close absolute top-4 right-4 cursor-pointer">(close)</h1>
 
-    <h1 style="display: flex;flex-direction: row;">
+    <h1 class="flex flex-row">
         <a href="/">INDEX JOURNAL</a>
         <?php foreach (page('issues')->children()->listed()->flip()->slice(0, 1) as $issue) : ?>
             <a href="<?= $issue->url() ?>" class="current-issue"><span>, Issue </span><span>No. </span><?= $issue->num() ?><span style="text-transform: uppercase;"> <?= $issue->title() ?></span></a>

--- a/site/snippets/pane.php
+++ b/site/snippets/pane.php
@@ -1,12 +1,12 @@
-<div class="pane fixed inset-0 z-50 bg-white hidden">
-  <span class="pane-close absolute top-4 right-4 cursor-pointer">Close</span>
+<div class="pane fixed inset-0 z-[250] bg-white hidden w-screen h-screen">
+  <span class="pane-close absolute top-4 right-4 uppercase text-[var(--font-body)] cursor-pointer">Close</span>
   <header>
     <h1><a href=".">INDEX JOURNAL</a>, <span>Issue No. 2 LAW</span></h1>
   </header>
-  <div class="pane-inner">
-    <figure>
-      <img src="assets/images/03.jpg" style="max-width: 60%; margin: 0 auto;" alt="Giambattista Tiepolo – The Banquet of Cleopatra">
-      <figcaption> Ludwig Hirschfeld-Mack, ‘Desolation (Internment Camp, Orange NSW, 1941)’ <br>woodcut, printed in black ink on thin ivory wove paper, 21.6 x 13.5 cm; Art Gallery of NSW.</figcaption>
+  <div class="pane-inner flex justify-center items-center w-screen h-screen">
+    <figure class="max-w-[60%]">
+      <img class="max-w-full block" src="assets/images/03.jpg" alt="Giambattista Tiepolo – The Banquet of Cleopatra">
+      <figcaption>Ludwig Hirschfeld-Mack, ‘Desolation (Internment Camp, Orange NSW, 1941)’ <br>woodcut, printed in black ink on thin ivory wove paper, 21.6 x 13.5 cm; Art Gallery of NSW.</figcaption>
     </figure>
   </div>
 </div>

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -1,3 +1,40 @@
-/* @tailwind base; */
+@tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  @font-face {
+    font-family: "DinSynt";
+    src: url("../fonts/DinamoSynt-Regular.woff");
+    font-style: normal;
+  }
+
+  @font-face {
+    font-family: "DinSynt";
+    src: url("../fonts/DinamoSynt-Oblique.woff");
+    font-style: italic;
+  }
+
+  * {
+    @apply m-0 p-0 box-border font-normal antialiased;
+  }
+
+  html {
+    font-size: 1.1vw;
+  }
+
+  @media (max-width: 670px) {
+    html {
+      font-size: 18px;
+    }
+  }
+
+  body {
+    @apply font-sans leading-[1.15];
+    font-variant-ligatures: none;
+  }
+
+  figcaption {
+    @apply mt-4 text-left leading-tight text-sm;
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,9 @@
 module.exports = {
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['DinSynt', 'sans-serif'],
+      },
       // Adding custom utilities for scroll snap behavior
       scrollSnapType: {
         y: "y mandatory", // Enables vertical snapping


### PR DESCRIPTION
## Summary
- include Tailwind base layer for fonts and resets
- extend Tailwind config with DinSynt font
- migrate pane markup to Tailwind classes
- migrate menu pane layout to Tailwind
- apply font utility in header

## Testing
- `npm run build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tailwindcss)*

------
https://chatgpt.com/codex/tasks/task_b_684b8f43f514833293bfa1867db7e87e